### PR TITLE
Tile url

### DIFF
--- a/docs/devjs.md
+++ b/docs/devjs.md
@@ -71,29 +71,31 @@ aktuellen Einstellungen in die jeweiligen Platzhalter `%«name»%` geschrieben.
 var Geolocation = {
 
     default: {  // Default-Werte
-                mapOptions:
-                    {
-                        minZoom:%zoomMin%,
-                        maxZoom:%zoomMax%,
-                        scrollWheelZoom:true,
-                        gestureHandling:%defaultGestureHandling%,
-                        locateControl: %defaultLocateControl%,
-                        fullscreen:%defaultFullscreen%
-                    },
-                bounds: [%defaultBounds%],
-                boundsRect: {fill:false,stroke:false},
-                zoom: %defaultZoom%,
-                locationMarker:
-                    {
-                        className:   'geolocation-locate-location',
-                        weight:      3,
-                        radius:      9
-                    },
-                locationMarkerCircle:
-                    {
-                        className:   'geolocation-locate-accuracy',
-                    },
+        mapOptions:
+            {
+                keyMapset: %keyMapset%,
+                keyLayer: %keyLayer%,
+                minZoom:%zoomMin%,
+                maxZoom:%zoomMax%,
+                scrollWheelZoom:true,
+                gestureHandling:%defaultGestureHandling%,
+                locateControl: %defaultLocateControl%,
+                fullscreen:%defaultFullscreen%
             },
+        bounds: [%defaultBounds%],
+        boundsRect: {fill:false,stroke:false},
+        zoom: %defaultZoom%,
+        locationMarker:
+            {
+                className:   'geolocation-locate-location',
+                weight:      3,
+                radius:      9
+            },
+        locationMarkerCircle:
+            {
+                className:   'geolocation-locate-accuracy',
+            },
+    },
 
     icon: {},       // Icons (SVG)
 

--- a/docs/devmath.md
+++ b/docs/devmath.md
@@ -17,7 +17,7 @@
 
 Die Erde ist ein [Rotationselipsoid](https://de.wikipedia.org/wiki/Rotationsellipsoid), also eine an
 den Polen leicht abgeflachte Kugel. Das macht Rechenoperationen mit Koordinaten sowie die Abbildung
-der kugeligen Realität noch etwas kompliziert.
+der kugeligen Realität etwas komplizierter.
 
 In **Geolocation** ist die PHP-Bibliothek [**phpGeo**](https://github.com/mjaschen/phpgeo) von
 [Markus Jaschen](https://github.com/mjaschen) enthalten. Sie stellt eine Reihe von Klassen zur
@@ -30,7 +30,7 @@ die erweiterte Funktionen im Namespace `\Geolocation` bereitstellen.
     - Ausgabe in verschiedenen Zielformaten
     - Rechenoperatinen (Distanz/Richtung/Ziel)
 - `class Box`: Verwaltet einen rechteckigen Bereich
-    - Anlegen aus zwei gegeüberliegenden Eckpunkten (Point)
+    - Anlegen aus zwei gegenüberliegenden Eckpunkten (Point)
     - Abfrage diverser Daten (Eckpunkte, Nord/Süd/Ost/West)
     - Rechenoperationen (Außenkreis, Innenkreis, Zentrum, Contains, ExtendBy)
 - `class Math`: Auf phpGeo aufbauend eine Schnittstelle zu gängigen Rechenoperationen
@@ -40,7 +40,7 @@ die erweiterte Funktionen im Namespace `\Geolocation` bereitstellen.
 <a name="caveat"></a>
 ## Hinweise
 
-Leaflet selbst als Tool für die Darstellung hat Einschränkung in Bezug auf die
+Leaflet selbst als Tool für die Darstellung hat Einschränkungen in Bezug auf die
 [Datumslinie](https://de.wikipedia.org/wiki/Datumsgrenze) oder präziser, dem dortigen Meridian
 &#177;180°. Eine Box mit den Koordinaten `[[10,170],[15,-170];]` hat keine gezeichnete Breite von 20
 Längengraden über den Datumsgrenzen-Meridian, sondern von 340 Längengraden über den Null-Meridian.
@@ -151,7 +151,7 @@ kommt aber irgendwann an ihre Grenzen. Für weitere Informationen sei auf die
 verwiesen.
 
 Sofern die Einzelwerte nicht aus der Schreibweise als Länge bzw. Breite erkannt werden können, gilt
-die Reihenfolge "Länge,Breite".
+die Reihenfolge "Breite,Länge" (lat,lng).
 
 ```php
 use \Geolocation\Calc\Point;
@@ -210,7 +210,7 @@ dump(get_defined_vars());
     #lng: -105,00341892242
 }
 "latitude" => 39,753838
-"longitude" => -105,00341892242]
+"longitude" => -105,00341892242
 ```
 
 ### latLng()
@@ -718,7 +718,7 @@ dump(get_defined_vars());
 
 > static function byCorner( Point $cornerA, Point $cornerB ): self
 
-Die Box wird aus Punkten zwei diagonal gegenüberliegenden Punkten erzeugt.
+Die Box wird aus zwei diagonal gegenüberliegenden Punkten erzeugt.
 
 ```php
 use \Geolocation\Calc\Point;
@@ -767,8 +767,8 @@ dump(get_defined_vars());
 > static function byInnerCircle( Point $center, float $radius ): self
 
 Die Box wird aus dem Mittelpunkt und einem darum gezogenen Kreis gebildet. Die Box umschließt den
-Kreis. Der Radius (in Meter) ist die Distanz vom Mittelpunkt auf der SN- bzw. WE-Achse zum
-Mittelpunkt der Box-Seiten.
+Kreis. Der Radius (in Meter) ist die Distanz vom Mittelpunkt auf der Nord/Süd- bzw. West/Ost-Achse
+zum Mittelpunkt zu den Seiten der Box.
 
 ```php
 use \Geolocation\Calc\Point;
@@ -839,7 +839,7 @@ dump(get_defined_vars());
 
 Die Box wird um den Mittelpunkt gezeichnet. Breite und Höhe in Meter bestimmen die Größe.
 
-Anmerkung: Wenn Höhe und Breite identisch sind entspricht das `Box::byInnerCircle($center,$breite)`.
+Anmerkung: Wenn Höhe und Breite identisch sind entspricht das `Box::byInnerCircle($center,$breite/2)`.
 
 ```php
 use \Geolocation\Calc\Point;
@@ -962,7 +962,7 @@ die Punkte im Bedarfsfall jeweils neu abgefragt oder die Einzelwerte abgerufen w
 > function southWest(): Point
 
 Innerhalb der Box-Instanz sind `northEast()` und `southWest()` nicht existent da überflüssig.
-Die hier übergebenen Point-Instanzen sind für den Abruf neu angelegte Punkte. Wurde die Box z.B.
+Die hier übergebenen Point-Instanzen sind für den Abruf neu angelegter Punkte. Wurde die Box z.B.
 durch Hinzufügen eines Punktes erweitert, sind auch diese Point-Instanzen nicht mehr verwertbar.
 Die Punkte sollten im Bedarfsfall jeweils neu abgefragt oder ggf. die Einzelwerte abgerufen werden.
 
@@ -1078,7 +1078,7 @@ dump(get_defined_vars());
 
 > function geoJSONMultipoint( ?int $precision=null ): array
 
-Die Methode erzeugt einen Multipoint-Eintrag für einen geoJSON-Datensatz. Da LeafletJSs geoJSON nicht
+Die Methode erzeugt einen Multipoint-Eintrag für einen geoJSON-Datensatz. Da LeafletJS´  geoJSON nicht
 weiß, wie der Punkt dargestellt wird, muss der Code zur Darstellung des Datensatzes (1) erfahren,
 dass dieser Multipoint-Eintrag eine Box repräsentiert und (2) die Darstellung entsprechend
 durchführen. Beide Informationen müssten über die Properties übermittelt werden. Ohne individuelle
@@ -1246,8 +1246,8 @@ Der Radius ist in Meter angegeben.
 
 ```php
 <script>
-// Zuerst ein kleine Tool definieren, dass den Demo-Datensatz darstellt
-// konkret: wenn Property.radius dann Kreis
+// Zuerst ein kleines Tool definieren, das den Demo-Datensatz darstellt
+// konkret: wenn Property.radius, dann Kreis
 Geolocation.Tools.MyOnTheFlyTool = class extends Geolocation.Tools.GeoJSON
 {
     _pointToLayer(feature, latlng) {
@@ -1375,7 +1375,7 @@ dump(get_defined_vars());
 
 > function extendBy ( mixed $data ): self
 
-Die Box wird so vergrößert, dass alle angegebenen Punkte in den Boy-Grenzen liegen. Punkte, die
+Die Box wird so vergrößert, dass alle angegebenen Punkte in den Box-Grenzen liegen. Punkte, die
 bereits in der Box sind, werden ausgelassen. Eine Prüfung vorab ist nicht erforderlich. Die neue
 West-Ost-Distanz muss kleiner als 180° sein. Andernfalls bricht der Vorgang ebenfalls mit einer
 Exception ab.

--- a/docs/example/demo.html
+++ b/docs/example/demo.html
@@ -56,9 +56,9 @@
                                     class="map"
                                     map="{&quot;minZoom&quot;:3}"
                                     mapset="[
-                                        {&quot;layer&quot;:&quot;geolayer=1&quot;,&quot;label&quot;:&quot;Karte&quot;,&quot;attribution&quot;:&quot;Map Tiles &amp;copy; 2020 &lt;a href=\&quot;http:\/\/developer.here.com\&quot;&gt;HERE&lt;\/a&gt;&quot;},
-                                        {&quot;layer&quot;:&quot;geolayer=2&quot;,&quot;label&quot;:&quot;Satelit&quot;,&quot;attribution&quot;:&quot;Map Tiles &amp;copy; 2020 &lt;a href=\&quot;http:\/\/developer.here.com\&quot;&gt;HERE&lt;\/a&gt;&quot;},
-                                        {&quot;layer&quot;:&quot;geolayer=3&quot;,&quot;label&quot;:&quot;Hybrid&quot;,&quot;attribution&quot;:&quot;Map Tiles &amp;copy; 2020 &lt;a href=\&quot;http:\/\/developer.here.com\&quot;&gt;HERE&lt;\/a&gt;&quot;}
+                                        {&quot;layer&quot;:&quot;1&quot;,&quot;label&quot;:&quot;Karte&quot;,&quot;attribution&quot;:&quot;Map Tiles &amp;copy; 2020 &lt;a href=\&quot;http:\/\/developer.here.com\&quot;&gt;HERE&lt;\/a&gt;&quot;},
+                                        {&quot;layer&quot;:&quot;2&quot;,&quot;label&quot;:&quot;Satelit&quot;,&quot;attribution&quot;:&quot;Map Tiles &amp;copy; 2020 &lt;a href=\&quot;http:\/\/developer.here.com\&quot;&gt;HERE&lt;\/a&gt;&quot;},
+                                        {&quot;layer&quot;:&quot;3&quot;,&quot;label&quot;:&quot;Hybrid&quot;,&quot;attribution&quot;:&quot;Map Tiles &amp;copy; 2020 &lt;a href=\&quot;http:\/\/developer.here.com\&quot;&gt;HERE&lt;\/a&gt;&quot;}
                                         ]"
                                     dataset="{&quot;position&quot;:[47.516669,9.433338],&quot;bounds&quot;:[[47.5,9.3],[47.7,9.7]],&quot;marker&quot;:[[47.611593,9.296344],[47.586204,9.560653],[47.54378,9.686559]]}"
                                 ></rex-map>

--- a/docs/layer.md
+++ b/docs/layer.md
@@ -104,7 +104,7 @@ $layerConfigSet = \Geolocation\layer::getLayerConfigSet( [1,2,3] );
 ```
 ```
 array:4 [▼
-    "layer" => "geolayer=1"
+    "layer" => "1"
     "label" => "Karte"
     "type" => "b"
     "attribution" => "Map Tiles &copy; 2020 <a href="http://developer.here.com">HERE</a>"

--- a/docs/mapset.md
+++ b/docs/mapset.md
@@ -85,19 +85,19 @@ Hintergrund benutzt. Details und weitere Beispiele finden sich in den [Entwickle
     ```
     array:3 [▼
         0 => array:4 [▼
-            "layer" => "geolayer=1"
+            "layer" => "1"
             "label" => "Karte"
             "type" => "b"
             "attribution" => "Map Tiles &copy; 2020 <a href="http://developer.here.com">HERE</a>"
         ]
         1 => array:4 [▼
-            "layer" => "geolayer=2"
+            "layer" => "2"
             "label" => "Satelit"
             "type" => "b"
             "attribution" => "Map Tiles &copy; 2020 <a href="http://developer.here.com">HERE</a>"
         ]
         2 => array:4 [▼
-            "layer" => "geolayer=3"
+            "layer" => "3"
             "label" => "Hybrid"
             "type" => "b"
             "attribution" => "Map Tiles &copy; 2020 <a href="http://developer.here.com">HERE</a>"

--- a/install/geolocation.js
+++ b/install/geolocation.js
@@ -5,31 +5,33 @@
 var Geolocation = {
 
     default: {  // Default-Werte
-                mapOptions:
-                    {
-                        minZoom:%zoomMin%,
-                        maxZoom:%zoomMax%,
-                        scrollWheelZoom:true,
-                        gestureHandling:%defaultGestureHandling%,
-                        locateControl: %defaultLocateControl%,
-                        fullscreen:%defaultFullscreen%
-                    },
-                bounds: [%defaultBounds%],
-                boundsRect: {fill:false,stroke:false},
-                markerColor: 'cornflowerblue',
-                positionColor: 'red',
-                zoom: %defaultZoom%,
-                locationMarker:
-                    {
-                        className:   'geolocation-locate-location',
-                        weight:      3,
-                        radius:      9
-                    },
-                locationMarkerCircle:
-                    {
-                        className:   'geolocation-locate-accuracy',
-                    },
+        keyMapset: %keyMapset%,
+        keyLayer: %keyLayer%,
+        mapOptions:
+            {
+                minZoom:%zoomMin%,
+                maxZoom:%zoomMax%,
+                scrollWheelZoom:true,
+                gestureHandling:%defaultGestureHandling%,
+                locateControl: %defaultLocateControl%,
+                fullscreen:%defaultFullscreen%
             },
+        bounds: [%defaultBounds%],
+        boundsRect: {fill:false,stroke:false},
+        markerColor: 'cornflowerblue',
+        positionColor: 'red',
+        zoom: %defaultZoom%,
+        locationMarker:
+            {
+                className:   'geolocation-locate-location',
+                weight:      3,
+                radius:      9
+            },
+        locationMarkerCircle:
+            {
+                className:   'geolocation-locate-accuracy',
+            },
+    },
 
     icon: {},       // Icons (SVG)
 
@@ -258,7 +260,7 @@ Geolocation.Classes.Map = class {
             delete mapset[tile].layer;
             layertype = mapset[tile].type || 'b';
             delete mapset[tile].type;
-            layer = L.tileLayer( 'index.php?'+geolayer+'&z={z}&x={x}&y={y}',mapset[tile] );
+            layer = L.tileLayer( 'index.php?'+Geolocation.default.keyLayer+'='+geolayer+'&z={z}&x={x}&y={y}',mapset[tile] );
             if( tile == defaultLayer ) layer.addTo( this.map );
             if( 'b' == layertype ){
                 this.layerControl.addBaseLayer( layer, label );

--- a/lib/config_form.php
+++ b/lib/config_form.php
@@ -210,6 +210,8 @@ class config_form extends \rex_config_form
                 ->addFile( $addonDir.'install/vendor/Leaflet.GestureHandling/leaflet-gesture-handling.min.js' )
                 ->replace( '//# sourceMappingURL=leaflet-gesture-handling.min.js.map','' )
                 ->addFile( $addonDir.'install/geolocation.js' )
+                ->replace( '%keyMapset%', '\''.KEY_MAPSET.'\'' )
+                ->replace( '%keyLayer%', '\''.KEY_TILES.'\'' )
                 ->replace( '%defaultBounds%', \rex_config::get(ADDON,'map_bounds') )
                 ->replace( '%defaultZoom%', \rex_config::get(ADDON,'map_zoom') )
                 ->replace( '%zoomMin%', \rex_config::get(ADDON,'map_zoom_min') )

--- a/lib/yform/dataset/layer.php
+++ b/lib/yform/dataset/layer.php
@@ -450,7 +450,7 @@ class layer extends \rex_yform_manager_dataset
      */
     public function getLayerConfig( ?string $locale ){
         return [
-            'layer' => KEY_TILES.'='.$this->id,
+            'layer' => $this->id,
             'label' => $this->getLabel( $locale ),
             'type' => $this->layertype,
             'attribution' => $this->attribution,


### PR DESCRIPTION
In der Mapset-Struktur stand die Layer-ID (also die Nummer des Kartentyps) bisher als `"layer":"geolayer=1"`. Da ist nun geändert in `"layer":"1",`. Der URL-Parameter wird jetzt im JS aus einem Element des Geolocation-Objektes und der Nummer aufgebaut. Der Umbau betrifft 

- Eintrag des Namens ("geolayer" und "geomapset") in das Geolocation-Objekt
- Aufbau der Abruf-URL im JS
- Dokumentation angepasst

Die alte Darstellung war aus Testzeiten über geblieben