### PR TITLE
Tool-Verwaltung geändert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## xx.xx.2022 <<next release>>
+
+- Bisher durfte ein Tool nur einmal auf der Karte erscheinen. Die Namenskonvention ist nun geändert.
+  Ein Tool-Name (z.B.`'position'`) kann durch ein per '|' angehängtes Suffix eindeutig gemacht
+  werden (z.B.`'position|xyz'`).
+- Der Event `Geolocation:dataset.ready` liefert jetzt auch die Referenz zu den Tools (`e.detail.tools`).
+- Tools werden in einer Instanz der JS-Klasse `Map` verwaltet und sind nun über den Namen
+  auffindbar.
+- Die Daten in einem Tool können per abgerufen werden (`«tool».getValue()`).
+- Dokumentation aktualisiert.
+
 ## 05.03.2022 Zweite 1.0 beta-2 
 
 - Die Namen der Proxy-Aufrufe (geolayer, geomapset) sind im JS-Code abgelegt und werden JS-seitig in

--- a/docs/devgeojson.md
+++ b/docs/devgeojson.md
@@ -21,7 +21,7 @@ als Datensatz darzustellen. Auf PHP-Seite ist es ein Array, auf der JS-Seite ein
 
 Einen Anwendungsüberblick liefert das [Tutorial](https://blog.codecentric.de/2018/03/geojson-tutorial/)
 von [codecentric](https://www.codecentric.de/). Kenntnisse über geoJSON und die kleinen Unterschiede
-zu LeafLetJS (z.B. `[lon,lat]` statt `[lat,lon]`) wird vorausgesetzt.
+zu LeafLetJS (z.B. `[lng,lat]` statt `[lat,lng]`) wird vorausgesetzt.
 
 Diese Dokumentation setzt auf dem [Anwendungsbeispiel](https://leafletjs.com/examples/geojson/) in
 der Leaflet-Dokumentation auf. Die Beispieldaten liegen als PHP-Array in der Datei
@@ -62,7 +62,7 @@ Universalmethode `L.geoJSON( geojsonData, options )`. Der Code in einem Demo-Aus
 
 ```php
 include \rex_path::addon(\Geolocation\ADDON,'docs/example/geojson_data.php');
-$position = [39.747,-104.995];  // lat,lon
+$position = [39.747,-104.995];  // lat,lng
 $zoom = 14;
 $radius = 1000;
 $color = 'blue';
@@ -186,7 +186,7 @@ Das neue Tool wird als `dataset` mit den Daten zur Buslinie verknüpft der Karte
 
 ```php
 include \rex_path::addon(\Geolocation\ADDON,'docs/example/geojson_data.php');
-$position = [39.747,-104.995];  // lat,lon
+$position = [39.747,-104.995];  // lat,lng
 $zoom = 14;
 $radius = 1000;
 $color = 'blue';
@@ -244,7 +244,7 @@ Das neue Tool wird als `dataset` mit den Daten der Verleihstationen verknüpft d
 
 ```php
 include \rex_path::addon(\Geolocation\ADDON,'docs/example/geojson_data.php');
-$position = [39.747,-104.995];  // lat,lon
+$position = [39.747,-104.995];  // lat,lng
 $zoom = 14;
 $radius = 1000;
 $color = 'blue';
@@ -295,7 +295,7 @@ Das neue Tool wird als `dataset` mit den Daten des Coors Field verknüpft der Ka
 
 ```php
 include \rex_path::addon(\Geolocation\ADDON,'docs/example/geojson_data.php');
-$position = [39.747,-104.995];  // lat,lon
+$position = [39.747,-104.995];  // lat,lng
 $zoom = 14;
 $radius = 1000;
 $color = 'blue';

--- a/docs/devjs.md
+++ b/docs/devjs.md
@@ -221,16 +221,12 @@ document.addEventListener( 'geolocation:map.ready', function(e){
 Die Karte kann auf Wunsch auch direkt als Leaflet-Karte ohne Zwischenschaltung von
 **Geolocation**-Tools verwaltet werden. Dazu muss die Leaflet-Instanz identifiziert werden.
 **Geolocation** triggert einen Custom-Event auf auf dem Karten-Container, nachdem die Karte geladen
-wurde. Tatsächlich ist es ein verlängerter Load-Event der Leaflet-Karte.
+wurde. Tatsächlich ist es ein verlängerter Load-Event der Leaflet-Karte. Die Elemente des Events sind
 
-```js
-this.map.on( 'load', function(e){
-    ...
-    map.getContainer().dispatchEvent(
-        new CustomEvent('geolocation:map.ready', { 'detail':{'container':container, 'map':this.map} })
-    );
-}, this);
-```
+| Name | Beschreibung |
+| --- | --- |
+| e.detail.map | Die Leaflet-Karteninstanz |
+| e.detail.container | `<rex-map>`-Instanz (Karten-Container); entspricht `map.getContainer()` |
 
 Der Event wird von der `<rex-map>`-Instanz (Karten-Container) abgefeuert, während die Instanz
 angelegt wird. Da der Event aufsteigt, kann er aber auf Ebene `document` abgefangen werden. Im
@@ -242,14 +238,14 @@ Hier ein Anwendungsbeispiel:
 ```JS
 document.addEventListener( 'geolocation:map.ready', function(e){
     if ( 'myid' === e.detail.container.id ){
-        // Leaflet-Event "zoomend" belegen
-        e.detail.map.on('zoomend', function(e){
-            alert( Geolocation.i18n('Zoom finished') );
-        });
         // setData abfangen
         e.detail.container.addEventListener( 'geolocation:dataset.ready', function(e){
             alert( Geolocation.i18n('Map updated') );
         },false);
+        // Leaflet-Event "zoomend" belegen
+        e.detail.map.on('zoomend', function(e){
+            alert( Geolocation.i18n('Zoom finished') );
+        });
     }
 },false);
 ```
@@ -258,12 +254,25 @@ document.addEventListener( 'geolocation:map.ready', function(e){
 ### geolocation:dataset.ready
 
 Der Event wird ausgelöst, wenn der Karte ein neuer Dataset hinzugefügt wurde. Der alte Dataset wurde
-entfernt, die Tools des neuen Dataset auf die Karte geschrieben.
+entfernt, die Tools des neuen Dataset auf die Karte geschrieben. Der Event liefert Informationen zur
+Karte und zu den Tools:
+
+| Name | Beschreibung |
+| --- | --- |
+| e.detail.map | Die Leaflet-Karteninstanz |
+| e.detail.container | `<rex-map>`-Instanz (Karten-Container); entspricht `map.getContainer()` |
+| e.detail.tools | Der Link zu einer JS-MAP-Instanz, die die Tools verwaltet |
 
 ```JS
 document.addEventListener( 'geolocation:dataset.ready', function(e){
     if ( 'myid' === e.detail.container.id ){
-        alert( Geolocation.i18n('Map updated') );
+        let positionTool = e.detail.tools.get('position');
+        if( positionTool && positionTool.getValue() ) {
+            let position = positionTool.getValue();
+        } else {
+            let position = e.detail.map.getCenter();
+        }
+        alert( Geolocation.i18n('Map updated - '+position.toString()) );
     }
 },false);
 ```
@@ -323,7 +332,7 @@ echo '<div rex-map ',\rex_string::buildAttributes($attributes),'></div>';
 ### CSS zur Grundformatierung des Karten-Containers
 
 Leaflet-Karten erfordern, dass dem Container-Tag eine Mindesthöhe mitgegeben ist. Die Default-Höhe
-eine DIV-Tags ist "0". Der Tag wird im CSS wie zuvor beschrieben über das Attribut `rex-map`
+eines DIV-Tags ist "0". Der Tag wird im CSS wie zuvor beschrieben über das Attribut `rex-map`
 identifiziert.
 
 ```css
@@ -405,4 +414,4 @@ let scriptPath = Geolocation.sPath;
 ```
 
 Falls eigene Scripte, die in die Datei _geolocation.min.js_ kompiliert wurden, Ressourcen im
-Asset-Verzeichnis zuverlässig finden sollen.
+Asset-Verzeichnis zuverlässig finden sollen, kann über den sPath der konkrete NAme gebildet werden.

--- a/docs/devphp.md
+++ b/docs/devphp.md
@@ -74,8 +74,12 @@ per Fragment generiert:
 | --- | --- | --- |
 | ::take($id) | Ruft den per $id angegebenen Datensatz ab.<br>Falls $id fehlt wird der Default-Kartensatz herangezogen | fehlertolerantes `mapset::get()` |
 | ->attributes($name,$value)<br>->attributes([$name1=>$value1,..]) | Ein HTML-Attribut oder ein Array mit HTML-Attributen, dass dem Karten-Tag zugefügt wird (`name="value" ...`) | nicht zulässig: mapset, dataset, map |
-|->dataset($tool,$data)<br>->dataset([$tool1=>data1,..]) | Kartendaten je Tool. Alle Angaben werden konsolidiert in ein Array an das Ausgabe-Fragment übergeben | Toolnamen müssen klein geschrieben sei |
+|->dataset($tool,$data)<br>->dataset([$tool1=>data1,..]) | Kartendaten je Tool. Alle Angaben werden konsolidiert in ein Array an das Ausgabe-Fragment übergeben. | Toolnamen müssen klein geschrieben sei |
 | ->parse($fragment) | Die Methode erzeugt auf Basis der zuvor angegebenen Daten das HTML. Dazu wird entweder das angegebene Fragment genutzt oder das für den Kartensatz voreingestellte. | |
+
+Tools sollten je Karte nur einmal vorkommen. Wenn trotzdem mehrere Instanzen einer Tool-Klasse
+erforderlich sind, kann der Name durch ein Suffix eindeutig gemacht werden. Das Suffix wird mit
+`|` angehängt (`position|eins`).  
 
 Die Methoden können verkettet werden:
 ```PHP
@@ -146,7 +150,7 @@ die Auswahl des Kartensatzes gespeichert ist.
 
 
 <a name="template"></a>
-## Template: css|js einbinden
+## Template: CSS und JS einbinden
 
 Die Html-Tags zum Einbinden der Assets können über eine Hilfsfunktion generiert werden. Dabei wird
 berücksichtigt, dass möglicherweise gar keine Assets geladen werden sollen. Näheres ist in den
@@ -196,7 +200,7 @@ Werten:
 
 - in `REX_VALUE[1]` steht eine Kartenüberschrift
 - in `REX_VALUE[2]` steht die ID des für die Ausgabe heranzuziehenden Kartensatzes
-- in `REX_VALUE[3]` steht die eine Koordinate (Position) der Form `lat,lon` (Zahlen mit Dezimalpunkt)
+- in `REX_VALUE[3]` steht die eine Koordinate (Position) der Form `lat,lng` (Zahlen mit Dezimalpunkt)
 - in `REX_VALUE[4]` steht die Größe des darzustellenden Umkreises um den Punkt in km.
 
 <a name="input"></a>
@@ -260,11 +264,11 @@ Im Beispiel werden die Daten wie folgt aufbereitet:
 - Als Kartenauschnitt wird ein Rechteck `$bounds` über Mittelpunkt und Radius errechnet
 
 Als Beispiel für (1) die individualisierte Darstellung von geoJSON-Datensätzen und (2) für die
-Bereitstellungen eigener [Darstellungstools](devtools.md) direkt im Code wird ein.
-- geoJSON-Datensatz mit Mittelpunkt und Radius zur Kreisdarstellung angelegt
+Bereitstellungen eigener [Darstellungstools](devtools.md) direkt im Code wird ein
+- geoJSON-Datensatz mit Mittelpunkt und Radius zur Kreisdarstellung angelegt,
 - ein Tool als Erweiterung des [geoJSON-Basistools](devgeojson.md) zur passgenauen Darstellung
-  ausgegeben.
-- Sichergestellt, dass das Tool im Javascript nur einmal angelegt wird.
+  ausgegeben,
+- sichergestellt, dass das Tool im Javascript nur einmal angelegt wird.
 
 Die Kartenausgabe beinhaltet
 - Mapset abrufen mit Fallback auf den Default-Kartensatz

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -54,7 +54,7 @@ Die Einstellungen sind Vorbelegungen bzw. Parameter für die Darstellung von Kar
     positioniert werden kann.
 
     Die Angabe ist immer ein Satz aus zwei Koordinaten, die die gegenüberliegenden Ecken eines
-    Rechtecks beschreiben. Die Schreibweise ist `[latA,lonA],[latB,lonB]`, also jeweils "Längengrad,
+    Rechtecks beschreiben. Die Schreibweise ist `[latA,lngA],[latB,lngB]`, also jeweils "Längengrad,
     Breitengrad".
 
     Beispiel-Code:

--- a/lib/yform/dataset/mapset.php
+++ b/lib/yform/dataset/mapset.php
@@ -40,7 +40,6 @@
         take            Alternative zu get, aber mit Fallback auf die Default-Karte
         attributes      sammelt die sonstigen HTML-Attribute ein
         dataset         sammelt die Karteninhalte ein (siehe Geolocation.js -> Tools)
-        event
         parse           erzeugt Karten-HTML gem. vorgegebenem Fragment
 
 */
@@ -440,7 +439,7 @@ class mapset extends \rex_yform_manager_dataset
      * sammelt die Karteninhalte ein (siehe Geolocation.js -> Tools)
      *
      * Darüber werden dem Kartensatz die Inhalte (Marker etc.) hinzugefügt. Sie landen als
-     * DATSSET-Attribut im Karten-HTML.
+     * DATASET-Attribut im Karten-HTML.
      * Siehe Doku zum Thema "Tools"
      *
      * Entweder wird als $name ein Array ['tool_a'=>'inhalt',..] angegeben oder der Tool-Name.


### PR DESCRIPTION
Da das Addon eher als Demo gedacht war, sind einige Konzepte unterentwickelt. Z.B. darf im PHP (`$map->dataset('xyz',$daten)`) ein Darstellungstool nur einmal eingebaut werden. JS-seitig werden die Tools als Array verwaltet, also ohne jeden Namensbezug. Dieser PR soll die Designschwäche beheben:

- Tools dürfen merhrfach zugeordnet werden. Dazu wurde einfach die Namenskonvention erweitert.
- Die Identifizierbarkeit der Tools in eigenem, ergänzenden JS wird ermöglicht
- Tools können ihren aktuellen Wert/Datensatz ausgeben; damit wird Interaktivität zur Karte ("Rückkanal") vorbereitet.

In der geänderten Namenskonvention wird  der Toolname über `«tool»|«suffix»` eindeutig gemacht werden, also angehängtes `|«suffix»`.

Die interne Verwaltung der Tools erfolgt nun als Map-Klasse (nicht mit "Karte" verwechseln, es ist die JS-Klasse "Map"). Das einzelne Tool kann dann per `map.tools.get('«identifier»')` identifiziert werden.

Das Tools-Objekt wird auch im Event `Geolocation:dataset:ready` mitgeliefert (`e.detail.tools`).

Der aktuelle Tool-Wert kann über `tool.getValue()` abgerufen werden. Im Normalfall (nicht interaktive Tools) wird der
Eingangswert zurückgegeben. Interaktive Tools müssen die Methode passend überschreiben.