### PR TITLE
Installation: Konstanten werden nicht gesetzt

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -31,7 +31,7 @@ define('Geolocation\LOAD',true);
 // if URL contains geolayer=«tileId» the request is supposed to be a tile-request
 // worked on by Geolocation\layer::sendTile
 //
-$tileLayer = \rex_request( 'KEY_TILES', 'integer', null );
+$tileLayer = \rex_request( KEY_TILES, 'integer', null );
 if( null !== $tileLayer ) {
     layer::sendTile( $tileLayer );
     exit();
@@ -42,7 +42,7 @@ if( null !== $tileLayer ) {
 // if URL contains geomapset=«mapId» the request is supposed to be a mapset-request
 // worked on by Geolocation\mapset::sendMapset
 
-$mapset = \rex_request( 'KEY_MAPSET', 'integer', null );
+$mapset = \rex_request( KEY_MAPSET, 'integer', null );
 if( null !== $mapset ) {
     mapset::sendMapset( $mapset );
     exit();

--- a/install.php
+++ b/install.php
@@ -184,6 +184,8 @@ try {
     $config['Geolocation\\LOAD'] = $config['scope']['load'];
     foreach( $config as $k=>$v ) {
         if( 'Geolocation\\' !== substr($k,0,12) ) continue;
+        // DEFINE sofort ausführen, falls \Geolocation\config_form::compileAssets die Konstanten benötigt
+        define($k,$v);
         if( is_string($v) ) {
             $v = "'$v'";
         } elseif( is_bool($v) ) {

--- a/install.php
+++ b/install.php
@@ -182,10 +182,10 @@ try {
     // Ausgewählte Vorgabewerte als "define(...)" in die boot.php schreiben
     $defines = PHP_EOL;
     $config['Geolocation\\LOAD'] = $config['scope']['load'];
+    $definedValues = [];
     foreach( $config as $k=>$v ) {
         if( 'Geolocation\\' !== substr($k,0,12) ) continue;
-        // DEFINE sofort ausführen, falls \Geolocation\config_form::compileAssets die Konstanten benötigt
-        define($k,$v);
+        $definedValues[$k] = $v;
         if( is_string($v) ) {
             $v = "'$v'";
         } elseif( is_bool($v) ) {
@@ -201,7 +201,7 @@ try {
 
     // Die JS/CSS-Dateien neu kompilieren, um Instanz-eigene Erweiterungen und Parameter
     // aus data/addons/geolocation einzubinden
-    \Geolocation\config_form::compileAssets( __DIR__.'/' );
+    \Geolocation\config_form::compileAssets( __DIR__.'/',$definedValues );
     $msg[] = $this->i18n( 'install_assets_prepared' );
 
     // Den Ordner 'data/addons/geolocation/assets' falls vorhanden in den Ordner 'assets/addons/geolocation' kopieren

--- a/lib/config_form.php
+++ b/lib/config_form.php
@@ -176,7 +176,7 @@ class config_form extends \rex_config_form
      *   @param array        Optional: Array mit Konstanten falls aus der install.php aufgerufen
      *                       Überschreiben gleichnamiger Konstanten aus der boot.php (Geolocation\xyz)
      */
-    static function compileAssets( ?string $addonDir=null ) : void
+    static function compileAssets( ?string $addonDir=null, array $constant=[] ) : void
     {
 
         $addonDir = $addonDir ?: \rex_path::addon(ADDON);


### PR DESCRIPTION
1) Dreht PR #44 zurück, das war nicht die Lösung.
2) Lösung: neue Konstanten sofort setzen (`define(...)`, damit sie beim Kompilieren der Assets direkt verfügbar sind.

Erklärung: einige Werte werden bei der Installation als Konstanten direkt in die boot.php geschrieben. Anschließend kompiliert die Installation die Assets neu zusammen, benötigt dabei z. Zt. zwei der Konstanten (KEY_MAPSET, KEY_TILES). Da hier die boot.php noch nicht ausgeführt wurde, die Konstanten also fehlen, gibt es die übliche Fehlermeldung im Log ("KEY_MAPSET not defined, assumed 'KEY_MAPSET'" oder so). Der Code st nun so geändert, dass die Konstanten auch sofort in der Installation aktiviert werden. 

Danke für den Hinweis an @AndiLeni und an @alxndr-w für´s Aufwecken