### PR TITLE
 Rexstan-Überarbeitung, Code-Style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Bearbeitung mit RexStan und Bereinigung diverser Fehler. Das alles führt zu ein
 - Klasse `Geolocation\cronjob` umbenannt in `Geolocation\Cronjob`; Aufrufe und Doku angepasst. (#52)
 - Klasse `Geolocation\tools` umbenannt in `Geolocation\Tools`; Aufrufe und Doku angepasst. (#53)
 - Klasse `Geolocation\config_form` umbenannt in `Geolocation\ConfigForm`; Aufrufe und Doku angepasst. (#66)
-- RexStan-gesteuerte Überarbeitung aller PHP-Dateien (Level 8, PHP 8.0-8.2, Extensions REDAXO Superglobals, Bleeding-Edge, Strict-Mode, Deprecation Warnings, phpstan-dba, dead code) und Code-Formatierung im REDAXO-Standard (#54 ... #62, #66) 
+- RexStan-gesteuerte Überarbeitung aller PHP-Dateien (Level 8, PHP 8.0-8.2, Extensions REDAXO Superglobals, Bleeding-Edge, Strict-Mode, Deprecation Warnings, phpstan-dba, dead code) und Code-Formatierung im REDAXO-Standard (#54 ... #62, #66, #68) 
 
 ## 06.05.2022 1.0.2
 


### PR DESCRIPTION
- Code-Style
  - REDAXOSs PHP-CS-Fixer
- RexStan
  - Level 8
  - PHP
    - 8.0
    - 8.1
    - 8.2
  - Extensions
    - REDAXO Superglobals
    - Bleeding-Edge
    - Strict-Mode
    - Deprecation Warnings
    - phpstan-dba
    - deadcode

Anmerkungen im Code mit `STAN:` markiert. 
