### PR TITLE
lib/Cronjob.php: Rexstan-Überarbeitung, Code-Style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Bearbeitung mit RexStan und Bereinigung diverser Fehler. Das alles führt zu ein
 - Klasse `Geolocation\cronjob` umbenannt in `Geolocation\Cronjob`; Aufrufe und Doku angepasst. (#52)
 - Klasse `Geolocation\tools` umbenannt in `Geolocation\Tools`; Aufrufe und Doku angepasst. (#53)
 - Klasse `Geolocation\config_form` umbenannt in `Geolocation\ConfigForm`; Aufrufe und Doku angepasst. (#66)
-- RexStan-gesteuerte Überarbeitung aller PHP-Dateien (Level: 8, PHP: 8.0-8.2, Extensions: REDAXO Superglobals, Bleeding-Edge, Strict-Mode, Deprecation Warnings, phpstan-dba, dead code) und Code-Formatierung im REDAXO-Standard (#54 ... #62, #66, #68, #70) 
+- RexStan-gesteuerte Überarbeitung aller PHP-Dateien (Level: 8, PHP: 8.0-8.2, Extensions: REDAXO Superglobals, Bleeding-Edge, Strict-Mode, Deprecation Warnings, phpstan-dba, dead code) und Code-Formatierung im REDAXO-Standard (#54 ... #62, #66, #68, #70 ... #71) 
 
 ## 06.05.2022 1.0.2
 

--- a/lib/Cronjob.php
+++ b/lib/Cronjob.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cronjob-Klasse; ruft die Bereinigungs-Methode in Geolocation\Cache auf.
- *
- * @package geolocation
  */
 
 namespace Geolocation;
@@ -15,11 +13,9 @@ class Cronjob extends rex_cronjob
     public const LABEL = 'Geolocation: Cleanup Cache';
 
     /**
-     *   Ausführende Aktion des Cron-Jobs.
+     * Ausführende Aktion des Cron-Jobs.
      *
-     *   Die eigentliche Rückmeldung erfolgt mit setMessage()
-     *
-     *   @return bool      true
+     * Die eigentliche Rückmeldung erfolgt mit setMessage()
      */
     public function execute(): bool
     {
@@ -29,9 +25,7 @@ class Cronjob extends rex_cronjob
     }
 
     /**
-     *   Typename.
-     *
-     *   @return string      Typename
+     * Typename.
      */
     public function getTypeName(): string
     {


### PR DESCRIPTION
Rexstan-Überarbeitung, Code-Style

- Code-Style
  - REDAXOSs PHP-CS-Fixer
- RexStan
  - Level 8
  - PHP
    - 8.0
    - 8.1
    - 8.2
  - Extensions
    - REDAXO Superglobals
    - Bleeding-Edge
    - Strict-Mode
    - Deprecation Warnings
    - phpstan-dba
    - deadcode