### PR TITLE
lib/calc/dms2.php: Rexstan-Überarbeitung, Code-Style, etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Bearbeitung mit RexStan und Bereinigung diverser Fehler. Das alles führt zu ein
 - Dateinamen `lib/exception.php` an den Klassennamen angeglichen (`lib/exception.php`) (#73)
 - Datentyp der Tabellenspalte `rex_geolocation_layer.online` von `text` in `int` geändert. Ggf. müssen eigene Datasets angepasst werden. (#77)
 - Workaround in `layer.php` für ein Typecast-Problem aus 'class dataset' (#79)
-- RexStan-gesteuerte Überarbeitung aller PHP-Dateien (Level: 8, PHP: 8.0-8.2, Extensions: REDAXO Superglobals, Bleeding-Edge, Strict-Mode, Deprecation Warnings, phpstan-dba, dead code) und Code-Formatierung im REDAXO-Standard (#54 … #62, #66, #68, #70 … #72, #74 … #76, #80)
+- Fehlermeldungen in `class InvalidParameters` gebündelt (#80,#81)
+- RexStan-gesteuerte Überarbeitung aller PHP-Dateien (Level: 8, PHP: 8.0-8.2, Extensions: REDAXO Superglobals, Bleeding-Edge, Strict-Mode, Deprecation Warnings, phpstan-dba, dead code) und Code-Formatierung im REDAXO-Standard (#54…#62, #66, #68, #70…#72, #74…#76, #80…#81)
 
 ## 06.05.2022 1.0.2
 

--- a/lib/InvalidParameter.php
+++ b/lib/InvalidParameter.php
@@ -44,6 +44,10 @@ class InvalidParameter extends \Geolocation\Exception
     public const BOXRESIZELAT = 16;
     /** @api */
     public const BOXRESIZELNG = 17;
+    /** @api */
+    public const DMS_DIGITS = 18;
+    /** @api */
+    public const DMS_DECIMALPOINT = 19;
 
     /**
      * @var list<string>
@@ -66,6 +70,8 @@ class InvalidParameter extends \Geolocation\Exception
         self::BOXRESIZE => 'Invalid resize hook-point "%s"',
         self::BOXRESIZELAT => 'Resize factor (latitude or lat/lng) expected larger than zero (given "%s")',
         self::BOXRESIZELNG => 'Resize factor (llongitude) expected larger than zero (given "%s")',
+        self::DMS_DIGITS => 'Invalid number of decimal places (negative value "%s" given")',
+        self::DMS_DECIMALPOINT => 'Replacement for decimal-point expected to be at least 1 charcter long; empty string or spaces.',
     ];
 
     /**


### PR DESCRIPTION
- Code-Style
  - REDAXOSs PHP-CS-Fixer
- RexStan
  - Level 8
  - PHP
    - 8.0
    - 8.1
    - 8.2
  - Extensions
    - REDAXO Superglobals
    - Bleeding-Edge
    - Strict-Mode
    - Deprecation Warnings
    - phpstan-dba
    - deadcode
- Fehlermeldungen über `InvalidParameter` ausgeben
- Doppelten Code ggü Parent-Klasse bereinigt