### PR TITLE
Feld "Layer|attribution" von "varchar(191)" in "text" geändert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@ Bearbeitung mit RexStan und Bereinigung diverser Fehler. Das alles führt zu ein
 - Klasse `Geolocation\mapset` umbenannt in `Geolocation\Mapset`; Aufrufe, Dateinamen und Doku angepasst. (#87)
 - Dateinamen `lib/exception.php` an den Klassennamen angeglichen (`lib/exception.php`) (#73)
 - Datentyp der Tabellenspalte `rex_geolocation_layer.online` von `text` in `int` geändert. Ggf. müssen eigene Datasets angepasst werden. (#77)
-- Workaround in `layer.php` für ein Typecast-Problem aus 'class dataset' (#79)
 - Fehlermeldungen in `class InvalidParameters` gebündelt (#80, #81)
-- Farbcodes (#123456) in `Geolocation.svgIconPin(..)` jetzt mit korrekt URI-escaped (#69⇒#94)
 - RexStan-gesteuerte Überarbeitung aller PHP-Dateien (Level: 8, PHP: 8.0-8.2, Extensions: REDAXO Superglobals, Bleeding-Edge, Strict-Mode, Deprecation Warnings, phpstan-dba, dead code) und Code-Formatierung im REDAXO-Standard (#54…#62, #66, #68, #70…#72, #74…#76, #80…#82, #84, #85)
 - Dokumentation (/docs) aktualisiert (#92, #93)
+- Bugfix:
+  - Workaround in `layer.php` für ein Typecast-Problem aus 'class dataset' (#79)
+  - Farbcodes (#123456) in `Geolocation.svgIconPin(..)` jetzt korrekt URI-escaped (#69⇒#94)
+  - Feld "attribution" im Layer-Formular von `varchar(191` in `text` geändert. Das Feld war zu klein. Beim Speichern gekapptes HTML kann zu Darstellungsproblemen führen. 
 - Vendor-Updates:
   - phpGeo 4.2.0 (#83)
   - Leaflet 1.9.3 (#99)

--- a/install.php
+++ b/install.php
@@ -79,7 +79,7 @@ try {
         ->ensureColumn(new rex_sql_column('name', 'varchar(191)'))
         ->ensureColumn(new rex_sql_column('url', 'text'))
         ->ensureColumn(new rex_sql_column('subdomain', 'varchar(191)'))
-        ->ensureColumn(new rex_sql_column('attribution', 'varchar(191)'))
+        ->ensureColumn(new rex_sql_column('attribution', 'text'))
         ->ensureColumn(new rex_sql_column('lang', 'text'))
         ->ensureColumn(new rex_sql_column('layertype', 'text'))
         ->ensureColumn(new rex_sql_column('ttl', 'int(11)', true))

--- a/install/tableset.json
+++ b/install/tableset.json
@@ -87,7 +87,7 @@
 				"prio": "5",
 				"type_id": "value",
 				"type_name": "text",
-				"db_type": "varchar(191)",
+				"db_type": "text",
 				"list_hidden": "1",
 				"search": "1",
 				"name": "attribution",


### PR DESCRIPTION
Bei längeren Attributions / Copyright-Angaben z.B. durch viel HTML (a href title ... ) kommen 191 Byte schnell an die Grenze. Daher in `text` geändert.