### PR TITLE
Dataset bereinigt und aktualisiert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Bearbeitung mit RexStan und Bereinigung diverser Fehler. Das alles führt zu ein
   - Workaround in `layer.php` für ein Typecast-Problem aus 'class dataset' (#79)
   - Farbcodes (#123456) in `Geolocation.svgIconPin(..)` jetzt korrekt URI-escaped (#69⇒#94)
   - Feld "attribution" im Layer-Formular von `varchar(191` in `text` geändert. Das Feld war zu klein. Beim Speichern gekapptes HTML kann zu Darstellungsproblemen führen. 
+  - Demo-Datensätze aktuaisiert (CyclOSM-Link tot und ausgetauscht), OSM nun als Mapset "1" default statt HERE. (#105) 
 - Vendor-Updates:
   - phpGeo 4.2.0 (#83)
   - Leaflet 1.9.3 (#99)

--- a/install/dataset.sql
+++ b/install/dataset.sql
@@ -6,9 +6,9 @@ INSERT INTO `%TABLE_PREFIX%geolocation_layer` (`id`, `name`, `url`, `subdomain`,
 (1, 'HERE: Standardkarte', 'https://{s}.base.maps.ls.hereapi.com/maptile/2.1/maptile/newest/normal.day/{z}/{x}/{y}/256/png8?apiKey=..........', '1234', 'Map Tiles &copy; 2020 <a href=\"http://developer.here.com\">HERE</a>', '[[\"de\",\"Karte\"],[\"en\",\"Map\"]]', 'b', 10000, 1000, 1),
 (2, 'HERE: Satelit', 'https://{s}.aerial.maps.ls.hereapi.com/maptile/2.1/maptile/newest/satellite.day/{z}/{x}/{y}/256/png8?apiKey=..........', '1234', 'Map Tiles &copy; 2020 <a href=\"http://developer.here.com\">HERE</a>', '[[\"de\",\"Satelit\"],[\"en\",\"Satellite\"]]', 'b', 10000, 1000, 1),
 (3, 'HERE: Hybrid (Karte+Satelit)', 'https://{s}.aerial.maps.ls.hereapi.com/maptile/2.1/maptile/newest/hybrid.day/{z}/{x}/{y}/256/png8?apiKey=..........', '234', 'Map Tiles &copy; 2020 <a href=\"http://developer.here.com\">HERE</a>', '[[\"de\",\"Hybrid\"],[\"en\",\"Hybrid\"]]', 'b', 1440, 1000, 1),
-(4, 'Open Street Map', 'https://{s}.tile.openstreetmap.de/{z}/{x}/{y}.png', 'abc', 'Map data &copy; <a href=\"http://openstreetmap.org/copyright\">OpenStreetMap contributors</a>', '[[\"de\",\"Karte\"],[\"en\",\"Map\"]]', 'b', 10000, 1000, 1),
-(5, 'CyclOSM - Open Bicycle render', 'https://dev.{s}.tile.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png', 'abc', '<a href=\"https://github.com/cyclosm/cyclosm-cartocss-style/releases\" title=\"CyclOSM - Open Bicycle render\">CyclOSM</a> | Map data: &copy; <a href=\"https://www.openstreetmap.org/copyright\">Ope', '[[\"de\",\"Radwege\"]]', 'o', 10000, 1000, 1),
-(6, 'OpenRailwayMap', 'https://{s}.tiles.openrailwaymap.org/standard/{z}/{x}/{y}.png', 'abc', 'Map data: &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors | Map style: &copy; <a href=\"https://www.Map data: &copy; <a href=\"https://www.openstreetmap.', '[[\"de\",\"Bahnstrecken\"]]', 'o', 10000, 1000, 1);
+(4, 'Open Street Map', 'https://{s}.tile.openstreetmap.de/{z}/{x}/{y}.png', 'abc', 'Map data: &copy; <a href=\"https://www.openstreetmap.org/\">OpenStreetMap</a> under <a href=\"https://www.openstreetmap.org/copyright\">ODdL</a>', '[[\"de\",\"Karte\"],[\"en\",\"Map\"]]', 'b', 10000, 1000, '1'),
+(5, 'Waymarked Trails: Radwege', 'https://tile.waymarkedtrails.org/cycling/{z}/{x}/{y}.png', '', '<a href=\"https://cycling.waymarkedtrails.org/">Waymarked Trails</a>', '[[\"de\",\"Radwege\"]]', 'o', 10000, 1000, '1'),
+(6, 'OpenRailwayMap', 'https://{s}.tiles.openrailwaymap.org/standard/{z}/{x}/{y}.png', 'abc', '&copy; <a href=\"https://openrailwaymap.org/\">OpenRailwayMap</a>', '[[\"de\",\"Bahnstrecken\"]]', 'o', 10000, 1000, '1');
 
 --
 -- Daten für Tabelle `rex_geolocation_mapset`
@@ -16,5 +16,5 @@ INSERT INTO `%TABLE_PREFIX%geolocation_layer` (`id`, `name`, `url`, `subdomain`,
 
 TRUNCATE TABLE `%TABLE_PREFIX%geolocation_mapset`;
 INSERT INTO `%TABLE_PREFIX%geolocation_mapset` (`id`, `name`, `title`, `layer`, `overlay`, `mapoptions`, `outfragment`) VALUES
-(1, 'base', 'Basiskarte', '1,2,3', '', 'default', ''),
-(2, 'osm', 'Open Street Map', '4', '5,6', 'default', '');
+(1, 'osm', 'Open Street Map', '4', '5,6', 'default', ''),
+(2, 'base', 'Basiskarte', '1,2,3', '', 'default', '');


### PR DESCRIPTION
- OSM ist nun Mapset 1 und damit default. 
- Attribution-Texte (Copyright) geändert
- Radwege-Overlay "CyclOSM" gibt es so nicht mehr. Ersetzt durch "Waymarked Trails: Radwege".

closes #96 