### PR TITLE
input.php vereinfacht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Bearbeitung mit RexStan und Bereinigung diverser Fehler. Das alles führt zu ein
 - RexStan-gesteuerte Überarbeitung aller PHP-Dateien (Level: 8, PHP: 8.0-8.2, Extensions: REDAXO Superglobals, Bleeding-Edge, Strict-Mode, Deprecation Warnings, phpstan-dba, dead code) und Code-Formatierung im REDAXO-Standard (#54…#62, #66, #68, #70…#72, #74…#76, #80…#82, #84, #85)
 - CSS-Assets `install/geolocation_be.css` und `install/geolocatin.css`in .scss umbenannt. (#104)
 - Dokumentation (/docs) aktualisiert (#92, #93)
+- `install.php`vereinfacht; nutzt nun ausschließlich `%table_prefix%` beim Import (#106) 
 - Bugfix:
   - Workaround in `layer.php` für ein Typecast-Problem aus 'class dataset' (#79)
   - Farbcodes (#123456) in `Geolocation.svgIconPin(..)` jetzt korrekt URI-escaped (#69⇒#94)

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -106,6 +106,7 @@ geolocation_install_cronjob_prepared = Der Cronjob zur Cache-Pflege ist angelegt
 geolocation_install_assets_prepared = Die Asset-Dateien sind neu compiliert.
 geolocation_install_tableset = Fehler beim Import der YForm-Formulare: «{0}»
 geolocation_install_table_demo_api = In den Beispieldaten muss unbedingt der eigene API-Key der HERE-Karten eingetragen werden!<br>Addon: Geolocation | Tab: Karte | Datensatz: HERE:... | Feld: URL.<br>Andernfalls blockt HERE die Kartenabrufe.
+geolocation_install_table_fill_error = Fehler beim Befüllen der Datenbank aus Datei «{1}»:<br>"{0}"<br>Die Tabellen sind leer.
 
 # URL-Test (yform-value, api)
 geolocation_yfv_url_description = URL mit Testbild-Abruf


### PR DESCRIPTION
Bisher wurde beim Demo-Import der Tabellen-Prefix expliziet angeglichen. Der Code dazu wurde entfernt; das läuft nun impliziet beim Import über %table_prefix% 