### PR TITLE
@-Zeichen in URLs erlauben

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Bearbeitung mit RexStan und Bereinigung diverser Fehler. Das alles führt zu ein
   - Individuelles CSS (`redaxo/data/geolocation/geolocation.css') kann auch in SCSS-Dateien stehen (Editor-frundlich) (#104)
   - Für Basiskarten im Kartensatz/Mapset kann die aktive Karte unabhängig von der Reihenfolge (bisher immer die erste) ber RAdio-Button aktiviert werden (#107)
   - Für Overlay-Karten im Kartensatz/Mapset können sofort sichtbare Overlays aktiviert werden (Checkbox); bisher waren die Karten immer initial ausgeblendet (#107)
+  - Karten-URLs nun auch mit @-Zusatz möglich (by @xong Robert Rupf) (#110)
 
 ## 06.05.2022 1.0.2
 

--- a/lib/yform/dataset/Layer.php
+++ b/lib/yform/dataset/Layer.php
@@ -278,7 +278,7 @@ class Layer extends rex_yform_manager_dataset
     public static function verifyUrl($field, $value, $return, $self, $elements): bool
     {
         $url = str_replace(['{', '}'], '', $value);
-        $xsRegEx_url = '/^(?:http[s]?:\/\/)[a-zA-Z0-9][a-zA-Z0-9._-]*\.(?:[a-zA-Z0-9][a-zA-Z0-9._-]*\.)*[a-zA-Z]{2,20}(?:\/[^\\/\:\*\?\"<>\|]*)*(?:\/[a-zA-Z0-9_%,\.\=\?\-#&]*)*$' . '/';
+        $xsRegEx_url = '/^(?:http[s]?:\/\/)[a-zA-Z0-9][a-zA-Z0-9._-]*\.(?:[a-zA-Z0-9][a-zA-Z0-9._-]*\.)*[a-zA-Z]{2,20}(?:\/[^\\/\:\*\?\"<>\|]*)*(?:\/[a-zA-Z0-9_%,\.\=\?\-#&@]*)*$' . '/';
         return 0 === preg_match($xsRegEx_url, $url);
     }
 


### PR DESCRIPTION
Ansonsten sind URLs mit `@2x` nicht möglich.