### PR TITLE
Tastaturunterstützung der Basiskarten-Auswahl verbessert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 10.03.2023 2.0.0 (under construction)
 
+- Bugfix:
+  - Tastatursteuerung in der Baisiskarten-Auswahl der Kartensätze korrigiert. (#139)
+
 beta3: 
 
 - Neu

--- a/install/geolocation_be.js
+++ b/install/geolocation_be.js
@@ -498,7 +498,7 @@ customElements.define('geolocation-layerselect-item',
              this.focus();
          }
          event.preventDefault();
-         event.stopPropagation();
+         event.stopImmediatePropagation();
      }
 
      /** 
@@ -514,7 +514,7 @@ customElements.define('geolocation-layerselect-item',
              this.focus();
          }
          event.preventDefault();
-         event.stopPropagation();
+         event.stopImmediatePropagation();
      }
 
      /** 
@@ -537,7 +537,7 @@ customElements.define('geolocation-layerselect-item',
              container.firstElementChild.click();
          }
          event.preventDefault();
-         event.stopPropagation();
+         event.stopImmediatePropagation();
      }
 
      /** 
@@ -553,9 +553,10 @@ customElements.define('geolocation-layerselect-item',
              let input = this.querySelector('input:not([type="hidden"])');
              if (input) {
                  input.click();
+                 this.focus();
              }
              event.preventDefault();
-             event.stopPropagation();
+             event.stopImmediatePropagation();
          }
      }
 
@@ -573,7 +574,7 @@ customElements.define('geolocation-layerselect-item',
              return this._moveDown(event)
          } else if ('Delete' == event.key) {
              return this._delete(event);
-         } else if (' ' == event.key) {
+         } else if (32 == event.keyCode) {
              return this._selectChoice(event);
          }
      }
@@ -688,7 +689,9 @@ customElements.define('gelocation-trigger',
             if (event.key == this.__key) {
                 event.stopImmediatePropagation();
                 event.preventDefault();
-                this._trigger();
+                if( !event.repeat ) {
+                    this._trigger();
+                }
             }
         }
 
@@ -731,4 +734,3 @@ customElements.define('gelocation-trigger',
             return this.__node;
         }
     });
-


### PR DESCRIPTION
Es geht um die Auswahl der Basiskarten für einen Kartensatz. 

Die Tastaturauswertung war subobtimal (Repeat-Erkennung und so). Es konnte z.B. passieren, dass beim Verschieben der Einträge ein Eintrag in einer Liste mit drei oder Mehr Einträgen immer sofort ans Ende schoben wurde statt nur um eine Position. 

Und die Selektion des aktiven Eintrags per Leertaste war auch eher erratisch. 