### PR TITLE
Bugfix beim Speichern mit "Übernehmen"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
-## 21.03.2023 2.0.0
+## 28.05.2023 2.0.1
 
+- Bugfix:
+  - Behebt einen Fehler `Unable to rollback, no transaction started before` beim Speichern eines Mapset-Formulars mit "Übernehmen" statt "Speichern".
+
+## 21.03.2023 2.0.0
 
 - Bugfix:
   - Tastatursteuerung in der Baisiskarten-Auswahl der Kartensätze korrigiert. (#139)
@@ -13,7 +17,6 @@ Beta3:
   - Per Config (z.B. im project AddOn) kann ein Socket-Proxy angegeben werden, falls erforderlich. Die config für den namespace geolocation lautet: 'socket_proxy' (#131) - Siehe (https://curl.se/libcurl/c/CURLOPT_PROXY.html).
 - Fixed
   - Probleme mit der Einbindung der Action-Buttons in YForm 4.1.0 wurden behoben (#130). 
-
 
 Beta2:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 28.05.2023 2.0.1
 
 - Bugfix:
-  - Behebt einen Fehler `Unable to rollback, no transaction started before` beim Speichern eines Mapset-Formulars mit "Übernehmen" statt "Speichern".
+  - Behebt einen Fehler `Unable to rollback, no transaction started before` beim Speichern eines Mapset-Formulars mit "Übernehmen" statt "Speichern" (#144)
 
 ## 21.03.2023 2.0.0
 

--- a/lib/yform/value/layerselect.php
+++ b/lib/yform/value/layerselect.php
@@ -96,7 +96,15 @@ class rex_yform_value_geolocation_layerselect extends rex_yform_value_be_manager
                 $this->setValue($value);
             }
         } elseif (0 < $this->params['main_id']) {
-            $selectedLayers = $this->getParam('manager_dataset')->getValue($this->subField);
+            // Strange! Verlässt man das Formular über "Speichern" ist der YOrm-Dataset verfügbar.
+            // Speichert man mit "Übernehmen" fehlt er.
+            try {
+                // "Speichern"
+                $selectedLayers = $this->getParam('manager_dataset')->getValue($this->subField);
+            } catch (\Throwable $th) {
+                // "Übernehmen"
+                $selectedLayers = $this->getParam('sql_object')->getValue($this->subField);
+            }
         } else {
             $selectedLayers = [];
             $value = [];

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: geolocation
-version: '2.0.0'
+version: '2.0.1'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/geolocation
 


### PR DESCRIPTION
In dem Fall kam es zu einem Fehler `Unable to rollback, no transaction started before` aus dem Manager. Tatsächlich war die Ursache im Geolocation-Value `layerselect` in der Zeile 99: 

`$this->getParam('manager_dataset')->getValue($this->subField);`

Beim "Speichern" existiert `param['manager_dataset']`, beim "Übernehmen" jedoch nicht, was im Hintergrund zu einem `getValue on null`-Fehler führt.