### PR TITLE
cUrl-Fehler ins Log schreiben

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 25.06.2023 2.1.0
+
+- Erweiterung:
+  - Fehler in der cUrl-Kommunikation mit dem Tile-Server werden in das Logfile geschrieben. (#145)
+
 ## 28.05.2023 2.0.1
 
 - Bugfix:

--- a/lib/yform/dataset/Layer.php
+++ b/lib/yform/dataset/Layer.php
@@ -503,6 +503,8 @@ class Layer extends rex_yform_manager_dataset
 
         // no reply at all, abort completely
         if ('0' === $returnCode) {
+            $msg = sprintf('Geolocation: Tile-Request failed (cUrl Error %d / %s)', curl_errno($ch), curl_error($ch));
+            rex_logger::logError(E_WARNING, $msg, __FILE__, __LINE__ - 8, rex_context::fromGet()->getUrl([], false).' ➜ '.$url);
             Tools::sendInternalError();
         }
 

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: geolocation
-version: '2.0.1'
+version: '2.1.0'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/geolocation
 


### PR DESCRIPTION
Zum besseren Nachvollziehen werden von cUrl gemeldete Fehler in´s Log geschrieben. Auslöser ist eine Rückmeldung im Slack von @TobiasKrais über fehlgeschlagene Tile-Abrufe. Deren Ursache lat nicht in Geolocation, sondern in Verbindungsproblemen des Servers mit dem Tile-Server (CURL ErrNo: 60, Error: server certificate verification failed. CAfile: none CRLfile: none)