### PR TITLE
Bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 01-07-2024 2.2.1
+
+- BugFix
+  - JS: Die Verlinkung der internen Geolocation -Strukturen im Karten-Container
+    erfolgte zu spät. `map._conainer.__rmMap` ist nun bei der Tool-initialisierung
+    wie geplant verfügbar. 
+
+
 ## 26-02-2024 2.2.0
 
 - Umbau (#152)

--- a/install/geolocation.js
+++ b/install/geolocation.js
@@ -188,6 +188,9 @@ Geolocation.Classes.Map = class {
         this.map = L.map( container, mapOptions );
         if( !this.map ) return null;
 
+        // frühzetig interne Verlinkung herstellen; notwendig für Tool-initialisierung
+        container.__rmMap = this;
+
         // Zusatzbuttons für "Zoom" und "Home" einbauen, indem das neue Zoom-Control aktiviert wird.
         this.map.on( 'load', function(e){
             this.zoomControl = this.zoomControl || new L.Control.GeolocationZoom().addTo(this.map);

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: geolocation
-version: '2.2.0'
+version: '2.2.1'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/geolocation
 


### PR DESCRIPTION
Ein JS-Problem wid durch diesen PR gelöst: Die internen Geolocation-Strukturen sind über eine Variable `__rmMap` mit dem Leaflet-Container (`map._container`). Bisher wurde die Variable `map._container.__rmMap` erst zugewiesen, wenn die komplette Initialisierung der Karte durchlaufen war. Wenn eines der Geolocation-Tools dabei Informationen aus `__rmMap` benötigt, waren sie eben noch nicht errreichbar. Durch die vorgezogene Initialisierung wird das Problem behoben. 