### PR TITLE
Tabellen-Prefix automatisch setzen (yform.php)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## xx-xx-2024 2.3.2
+
+- Bugfix
+  - Tabellennamen auch in der package.yml i.V.m pages/yform.php Prefix-neutral (#163)
+
 ## 25-07-2024 2.3.1
 
 - BugFix

--- a/package.yml
+++ b/package.yml
@@ -85,11 +85,11 @@ page:
 
 yform:
     geolocation/mapset:
-        table_name: rex_geolocation_mapset
+        table_name: geolocation_mapset
     geolocation/layer:
-        table_name: rex_geolocation_layer
+        table_name: geolocation_layer
     geolocation/service:
-        table_name: rex_geolocation_service
+        table_name: geolocation_service
 
 conflicts:
     packages:

--- a/pages/yform.php
+++ b/pages/yform.php
@@ -15,7 +15,7 @@
  *
  *      yform:
  *          «addon»/mytable1:
- *              table_name: rex_mytable_a     mandatory
+ *              table_name: mytable_a         mandatory; ohne Prefix «rex_»!!!
  *              show_title: FALSE/true        optional; default ist false!
  *              wrapper_class: myclass        optional
  *
@@ -26,7 +26,13 @@
 $yform = $this->getProperty('yform', []);
 $yform = $yform[\rex_be_controller::getCurrentPage()] ?? [];
 
-$table_name = rex_request('table_name', 'string', $yform['table_name'] ?? '');
+if( isset($yform['table_name']) ) {
+    $table_name = rex::getTable($yform['table_name']);
+} else {
+    $table_name = '';
+}
+
+$table_name = rex_request('table_name', 'string', $table_name);
 $show_title = true === ($yform['show_title'] ?? false);
 $wrapper_class = $yform['wrapper_class'] ?? '';
 


### PR DESCRIPTION
Das Script _pages/yform-php_ fügt den Tabellenprefix `rex_` jetzt selbst an den Tabellennamen an. Entsprechend sind die Tabellennamen in der _package.yml_ nun ohne Prefix. 