### PR TITLE
Methoden-Namen der EP-Callbacks adjustiert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## xx-xx-2024 3.0.0
+## xx-xx-2024 2.4.0
 
 - Bugfix
   - YForm-Tabellennamen für _pages/yform.php: via _package.yml_:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
-## xx-xx-2024 2.3.2
+## xx-xx-2024 3.0.0
 
 - Bugfix
-  - Tabellennamen auch in der package.yml i.V.m pages/yform.php Prefix-neutral (#163)
+  - YForm-Tabellennamen für _pages/yform.php: via _package.yml_:
+    - als reiner Tabellenname Prefix-neutral angeben (ohne rex_) (#163)
+    - indirekt über den Namen der ModelClass
+  - EP-Callbacks: 
+    - Aufruf in der "First class callable syntax"
+    - Methoden-Namen gem. PSR angepasst
+
 
 ## 25-07-2024 2.3.1
 

--- a/lib/Layer.php
+++ b/lib/Layer.php
@@ -18,8 +18,8 @@
  *
  * - Listenbezogen
  *
- *     YFORM_DATA_LIST_ACTION_BUTTONS  Button "Cache löschen" für die Datentabelle
- *     YFORM_DATA_LIST_QUERY           Initiale Sortiertung die Liste nach zwei Kriterien
+ *     epYformDataListActionButtons  Button "Cache löschen" für die Datentabelle
+ *     epYformDataListQuery          Initiale Sortiertung die Liste nach zwei Kriterien
  *
  * - AJAX-Abrufe
  *

--- a/lib/Layer.php
+++ b/lib/Layer.php
@@ -359,7 +359,7 @@ class Layer extends rex_yform_manager_dataset
      * @param rex_extension_point<array<string,string>> $ep
      * @return array<string,string>|void
      */
-    public static function YFORM_DATA_LIST_ACTION_BUTTONS(rex_extension_point $ep)
+    public static function epYformDataListActionButtons(rex_extension_point $ep)
     {
         // nur wenn diese Tabelle im Scope ist
         $table_name = $ep->getParam('table')->getTableName();
@@ -405,6 +405,15 @@ class Layer extends rex_yform_manager_dataset
     }
 
     /**
+     * @deprecated 3.0.0 Aufrufe auf "Layer::epYformDataListActionButtons" geändert
+     * @param rex_extension_point<array<string,string>> $ep
+     * @return array<string,string>|void
+     */
+    public static function YFORM_DATA_LIST_ACTION_BUTTONS(rex_extension_point $ep) { 
+        return self::epYformDataListActionButtons($ep);
+    }
+
+    /**
      * Initiale Sortiertung die Datentabelle nach zwei Kriterien.
      *
      * sorgt initial für die Sortierung nach 'layertyp,name', sofern es keine
@@ -412,10 +421,14 @@ class Layer extends rex_yform_manager_dataset
      * \rex_request('sort') als Indikator.
      *
      * @param rex_extension_point<rex_yform_manager_query<rex_yform_manager_dataset>> $ep
-     * @return void
+     * @return void|rex_yform_manager_query<rex_yform_manager_dataset>
      */
-    public static function YFORM_DATA_LIST_QUERY(rex_extension_point $ep)
+    public static function epYformDataListQuery(rex_extension_point $ep)
     {
+        if($ep->getSubject()->getTableName() !== self::table()->getTableName()) {
+            return;
+        }
+        
         // nichts tun wenn es schon einen Sort gibt
         if ('' === rex_request::request('sort', 'string', '')) {
             return;
@@ -430,6 +443,15 @@ class Layer extends rex_yform_manager_dataset
             ->resetOrderBy()
             ->orderBy('layertype')
             ->orderBy('name');
+    }
+
+    /**
+     * @deprecated 3.0.0 Aufrufe auf "Layer::epYformDataListQuery" geändert
+     * @param rex_extension_point<rex_yform_manager_query<rex_yform_manager_dataset>> $ep
+     * @return void|rex_yform_manager_query<rex_yform_manager_dataset>
+     */
+    public static function YFORM_DATA_LIST_QUERY(rex_extension_point $ep) { 
+        return self::epYformDataListQuery($ep);
     }
 
     // AJAX-Abrufe

--- a/lib/Mapset.php
+++ b/lib/Mapset.php
@@ -227,7 +227,7 @@ class Mapset extends rex_yform_manager_dataset
      * @param rex_extension_point<array<string,string|mixed>> $ep
      * @return array<string,string|mixed>|void
      */
-    public static function YFORM_DATA_LIST_ACTION_BUTTONS(rex_extension_point $ep)
+    public static function epYformDataListActionButtons(rex_extension_point $ep)
     {
         // nur wenn diese Tabelle im Scope ist
         $table_name = $ep->getParam('table')->getTableName();
@@ -324,6 +324,15 @@ class Mapset extends rex_yform_manager_dataset
             $ep->setSubject($buttons);
         }
 
+    }
+
+    /**
+     * @deprecated 3.0.0 Aufrufe auf "Layer::epYformDataListActionButtons" geändert
+     * @param rex_extension_point<array<string,string>> $ep
+     * @return array<string,string>|void
+     */
+    public static function YFORM_DATA_LIST_ACTION_BUTTONS(rex_extension_point $ep) { 
+        return self::epYformDataListActionButtons($ep);
     }
 
     // AJAX-Abrufe

--- a/lib/Mapset.php
+++ b/lib/Mapset.php
@@ -327,7 +327,7 @@ class Mapset extends rex_yform_manager_dataset
     }
 
     /**
-     * @deprecated 3.0.0 Aufrufe auf "Layer::epYformDataListActionButtons" geändert
+     * @deprecated 3.0.0 Aufrufe auf "Mapset::epYformDataListActionButtons" geändert
      * @param rex_extension_point<array<string,string>> $ep
      * @return array<string,string>|void
      */

--- a/lib/Mapset.php
+++ b/lib/Mapset.php
@@ -16,8 +16,8 @@
  *
  * - Listenbezogen
  *
- *     YFORM_DATA_LIST_ACTION_BUTTONS  Button "Cache löschen" für die Datentabelle
- *                                     Action-Button "delete" entfernen beim Default-Mapset
+ *     epYformDataListActionButtons  Button "Cache löschen" für die Datentabelle
+ *                                   Action-Button "delete" entfernen beim Default-Mapset
  *
  * - AJAX-Abrufe
  *

--- a/package.yml
+++ b/package.yml
@@ -85,9 +85,9 @@ page:
 
 yform:
     geolocation/mapset:
-        table_name: geolocation_mapset
+        table_name: FriendsOfRedaxo\Geolocation\Mapset
     geolocation/layer:
-        table_name: geolocation_layer
+        table_name: FriendsOfRedaxo\Geolocation\Layer
     geolocation/service:
         table_name: geolocation_service
 

--- a/pages/index.php
+++ b/pages/index.php
@@ -69,15 +69,14 @@ echo rex_view::title($this->i18n('geolocation_title'));
 // ggf. vorhandene API Messages ausgeben
 echo rex_api_function::getMessage();
 
-// #REVIEW: geht das auch ohne "\FriendsOfRedaxo\Geolocation"?
 // Liste 'rex_geolocation_mapset' um eine Action zum Löschen des Layer-Cache erweitern
-rex_extension::register('YFORM_DATA_LIST_ACTION_BUTTONS', '\FriendsOfRedaxo\Geolocation\mapset::YFORM_DATA_LIST_ACTION_BUTTONS');
+rex_extension::register('YFORM_DATA_LIST_ACTION_BUTTONS', Mapset::YFORM_DATA_LIST_ACTION_BUTTONS(...));
 
 // Liste 'rex_geolocation_layer' um eine Action zum Löschen der Layer-Caches erweitern
-rex_extension::register('YFORM_DATA_LIST_ACTION_BUTTONS', '\FriendsOfRedaxo\Geolocation\Layer::YFORM_DATA_LIST_ACTION_BUTTONS');
+rex_extension::register('YFORM_DATA_LIST_ACTION_BUTTONS', Layer::YFORM_DATA_LIST_ACTION_BUTTONS(...));
 
 // Liste 'rex_geolocation_layer' mit geänderter Sortierung
-rex_extension::register('YFORM_DATA_LIST_QUERY', '\FriendsOfRedaxo\Geolocation\Layer::YFORM_DATA_LIST_QUERY');
+rex_extension::register('YFORM_DATA_LIST_QUERY', Layer::YFORM_DATA_LIST_QUERY(...));
 
 // Und nun die aktuelle Seite anzeigen
 rex_be_controller::includeCurrentPageSubPath();

--- a/pages/index.php
+++ b/pages/index.php
@@ -70,13 +70,13 @@ echo rex_view::title($this->i18n('geolocation_title'));
 echo rex_api_function::getMessage();
 
 // Liste 'rex_geolocation_mapset' um eine Action zum Löschen des Layer-Cache erweitern
-rex_extension::register('YFORM_DATA_LIST_ACTION_BUTTONS', Mapset::YFORM_DATA_LIST_ACTION_BUTTONS(...));
+rex_extension::register('YFORM_DATA_LIST_ACTION_BUTTONS', Mapset::epYformDataListActionButtons(...));
 
 // Liste 'rex_geolocation_layer' um eine Action zum Löschen der Layer-Caches erweitern
-rex_extension::register('YFORM_DATA_LIST_ACTION_BUTTONS', Layer::YFORM_DATA_LIST_ACTION_BUTTONS(...));
+rex_extension::register('YFORM_DATA_LIST_ACTION_BUTTONS', Layer::epYformDataListActionButtons(...));
 
 // Liste 'rex_geolocation_layer' mit geänderter Sortierung
-rex_extension::register('YFORM_DATA_LIST_QUERY', Layer::YFORM_DATA_LIST_QUERY(...));
+rex_extension::register('YFORM_DATA_LIST_QUERY', Layer::epYformDataListQuery(...));
 
 // Und nun die aktuelle Seite anzeigen
 rex_be_controller::includeCurrentPageSubPath();

--- a/pages/yform.php
+++ b/pages/yform.php
@@ -15,10 +15,15 @@
  *
  *      yform:
  *          «addon»/mytable1:
- *              table_name: mytable_a         mandatory; ohne Prefix «rex_»!!!
+ *              table_name: mytable_a         mandatory; sieh Anmerkung unten!!!
  *              show_title: FALSE/true        optional; default ist false!
  *              wrapper_class: myclass        optional
  *
+ * "table_name" entweder als Tabellenname ohne den Prefix angegeben werden oder
+ * als Model-Class/Dataset-Class:
+ *      tabelle:            wird über rex::getTable($table_name) zu rex_tabelle
+ *      Namespace\Tabelle:  wird über $table_name::table()->getTableName() zu rex_tabelle
+ * 
  * @see https://friendsofredaxo.github.io/tricks/addons/yform/im-addon
  * @var \rex_addon $this
  */
@@ -27,7 +32,14 @@ $yform = $this->getProperty('yform', []);
 $yform = $yform[\rex_be_controller::getCurrentPage()] ?? [];
 
 if( isset($yform['table_name']) ) {
-    $table_name = rex::getTable($yform['table_name']);
+    $table_name = $yform['table_name'];
+    if( is_subclass_of($table_name,rex_yform_manager_dataset::class)) {
+        // table_name ist eine Dataset-Klasse
+        $table_name = $table_name::table()->getTableName();
+    } else {
+        // table_name ist ein Tabellenname
+        $table_name = rex::getTable($table_name);
+    }
 } else {
     $table_name = '';
 }


### PR DESCRIPTION
Anpassung der Namen (z.B. `Layer::YFORM_DATA_LIST`) in die PSR-konforme Schreibweise (z.B. `Layer::epYformDataList`) sowie damit verbundene Anpassungen im Code;

Aufrufe auf "First class callable syntax" umgestellt