### PR TITLE
V2.4 mit Bugfixes (Installation, Doku)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 03-12-2024 2.4.0
+## 06-12-2024 2.4.0
 
 - kleinere interne Modifikationen
   - YForm-Tabellennamen für _pages/yform.php: via _package.yml_ in zusätzlichen Schreibvarianten:
@@ -12,7 +12,9 @@
     - Methoden-Namen gem. PSR angepasst
 
 - Bugfix
-  Fehlendes `exit` in _manual.php_ führte bei der Bilderdurchleitung zu Warnings in Systemlog. Behoben.  
+  - Fehlendes `exit` in _manual.php_ führte bei der Bilderdurchleitung zu Warnings in Systemlog. Behoben.
+  - Update-Aktionen in _install.php_ wueden nicht korrekt Versions-abhängig angesteuert. Umgestellt auf "immer prüfen und ggf. ausführen"
+  - Typo korrigiert (Democode in _devmath.md_)
 
 
 ## 25-07-2024 2.3.1

--- a/docs/devmath.md
+++ b/docs/devmath.md
@@ -775,7 +775,7 @@ use FriendsOfRedaxo\Geolocation\Calc\Box;
 
 $center = Point::byLatLng( [39.747445394658,-104.99515771866] );
 $radius = 710;
-$rect = Box::byinnerCircle( $center, $radius );
+$rect = Box::byInnerCircle( $center, $radius );
 
 dump(get_defined_vars());
 ```

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -104,18 +104,20 @@ geolocation_manpage_devmath = Rechnen (PHP)
 
 # Installation
 geolocation_install_missing = Die Installationsdatei «{0}» fehlt!
-geolocation_install_table_prepared = Die Tabelle «{0}» ist angelegt.
+geolocation_install_table_prepared = Die Tabelle «{0}» ist angelegt bzw. aktualisiert.
 geolocation_install_table_demo = Die Tabellen sind mit Beispieldaten vorbefüllt.
 geolocation_install_table_filled = Die Tabellen sind vorbefüllt (Quelle: data-Verzeichnis).
-geolocation_install_tableset_prepared = Die YForm-Formulare sind angelegt.
+geolocation_install_tableset_prepared = Die YForm-Formulare sind angelegt bzw. aktualisiert.
 geolocation_install_cronjob_prepared = Der Cronjob zur Cache-Pflege ist angelegt.
 geolocation_install_assets_prepared = Die Asset-Dateien sind neu compiliert.
 geolocation_install_tableset = Fehler beim Import der YForm-Formulare: «{0}»
 geolocation_install_table_demo_api = In den Beispieldaten muss unbedingt der eigene API-Key der HERE-Karten eingetragen werden!<br>Addon: Geolocation | Tab: Karte | Datensatz: HERE:... | Feld: URL.<br>Andernfalls blockt HERE die Kartenabrufe.
 geolocation_install_table_fill_error = Fehler beim Befüllen der Datenbank aus Datei «{1}»:<br>"{0}"<br>Die Tabellen sind leer.
-geolocation_install_update2_ok = Breaking Change: Anpassung von Formularen und Tabellen beim Umstieg auf diese Version; siehe Hinweise im ChangeLog.
-geolocation_install_update2_warn = Achtung: Ab dieser Version haben sich mehrere Klassennamen und der Namespace geändert. Bitte in eigenem Code (z.B. Module und Templates) den Namespace von "Geolocation" in "FriendsOfRedaxo\Geolocation" ändern!
-geolocation_install_data_config_error = Das Namespace-Update auf "FriendsOfRedaxo\Geolocation" in der Datei "redaxo/data/geolocatin/config.xml" schlug fehl.
+geolocation_install_update1_ok = Doppelte Cronjobs («{0}») aus Version 1.x entfernt.
+geolocation_install_update2_ok = Namespace der Coronjob-Klasse angepasst (ab Version 2.0.0).
+geolocation_install_update3_ok = Zusätzliche Datenfelder initialisiert (ab Version 2.0.0).
+geolocation_install_update4_ok = Namespace angepasst in «data/geolocation/config.yml» (ab Version 2.0.0).
+geolocation_install_data_config_error = Das Namespace-Update auf "FriendsOfRedaxo\Geolocation" in der Datei «redaxo/data/geolocation/config.yml» schlug fehl.
 
 # URL-Test (yform-value, api)
 geolocation_yfv_url_description = Geolocation-Addon: URL mit Testbild-Abruf


### PR DESCRIPTION
@bitshiftersgmbh meldete Warnings im Sys-Log, die bei der Übertragung von Bildern in Doku-Artikeln entstanden. Es fehle ein `exit;` nachdem die Grafik abgeschickt war, um weitere Ausgaben zu vermeiden, die zu den Warnings führten.
(Diese Änderung ist leider als direkter Commit im Repo gelandet und nicht dem PR zugeordnet. Nur um es der Vollständigkeit halber zu erwähnen.)

@bitshiftersgmbh stellte während der Fehlersuche zu obigem fest, dass versionsabhängige Installationsschritte beim Update u.U. nicht durchgeführt wurden. Der Versionsvergleich (aktuelle Installation vs. Zielversion) funktionierte nicht wie erwartet. Entsprechende Teile der Installation sind nun so umgestellt, dass sie bei Install/Update immer durchlaufen werden, wenn die nötige Änderung noch nicht vorliegt.