### PR TITLE
Release 2.5.0 inl. Anpassung an YForm 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,6 @@
 # Changelog
 
-## 25-xx-xx 2.5.0-beta2
-
-- Neue Funktionen
-  - Dino-Logo hinzugefügt: README.MD und BE-Seite. (Dino by @skerbis)
-
-## 25-02-2025 2.5.0-beta1
+## 26.06.2025 2.5.0
 
 - Neue Funktionen
   - Implementierung eines Location-Picker zur interaktiven Auswahl einer Position
@@ -30,9 +25,11 @@
   - Klasse `SqlTools`: 
     - liefert Bausteine für SQL-Abfragen z.B. zur Umkreissuche
     - einfachere Implementierung der Spatial-Funktionen in SQL-Abfragen
+  - Dino-Logo hinzugefügt: README.MD und BE-Seite. (Dino by @skerbis)
 
 - kleinere interne Modifikationen
   - Vendor-Update für "mjaschen/phpgeo" aus Version 6.0.0
+  - Kompatibilität zu YForm 5 hergestellt wg. Wegfall der Plugins
 
 ## 07-12-2024 2.4.0
 

--- a/lib/Layer.php
+++ b/lib/Layer.php
@@ -399,7 +399,9 @@ class Layer extends rex_yform_manager_dataset
          * Stand 07.03.2023 gibt es nur das GH-Repo und keine neue Versionsnummer.
          * Daher auf das neue Fragment als Unterscheidungsmerkmal setzen.
          */
-        if (is_file(rex_path::plugin('yform', 'manager', 'fragments/yform/manager/page/list.php'))) {
+        if(is_file(rex_path::addon('yform', 'pages/manager.data_edit.php'))) {
+            $buttons['geolocationClearCache'] = '<a onclick="return confirm(\'' . $confirm . '\')" href="' . $href . '">' . $label . '</a>';
+        } else {
             $buttons['geolocationClearCache'] = [
                 'url' => $href,
                 'content' => $label,
@@ -407,8 +409,6 @@ class Layer extends rex_yform_manager_dataset
                     'onclick' => 'return confirm(\'' . $confirm . '\')',
                 ],
             ];
-        } else {
-            $buttons['geolocationClearCache'] = '<a onclick="return confirm(\'' . $confirm . '\')" href="' . $href . '">' . $label . '</a>';
         }
         $ep->setSubject($buttons);
     }

--- a/lib/Mapset.php
+++ b/lib/Mapset.php
@@ -320,7 +320,9 @@ class Mapset extends rex_yform_manager_dataset
              * Stand 07.03.2023 gibt es nur das GH-Repo und keine neue Versionsnummer.
              * Daher auf das neue Fragment als Unterscheidungsmerkmal setzen.
              */
-            if (is_file(rex_path::plugin('yform', 'manager', 'fragments/yform/manager/page/list.php'))) {
+            if(is_file(rex_path::addon('yform', 'pages/manager.data_edit.php'))) {
+                $buttons['geolocationClearCache'] = '<a onclick="return confirm(\'' . $confirm . '\')" href="' . $href . '">' . $label . '</a>';
+            } else {
                 $buttons['geolocationClearCache'] = [
                     'url' => $href,
                     'content' => $label,
@@ -328,8 +330,6 @@ class Mapset extends rex_yform_manager_dataset
                         'onclick' => 'return confirm(\'' . $confirm . '\')',
                     ],
                 ];
-            } else {
-                $buttons['geolocationClearCache'] = '<a onclick="return confirm(\'' . $confirm . '\')" href="' . $href . '">' . $label . '</a>';
             }
             $ep->setSubject($buttons);
         }

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,6 @@
 package: geolocation
-version: '2.5.0-beta2'
+version: '2.5.0'
+license: 'MIT'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/geolocation
 

--- a/package.yml
+++ b/package.yml
@@ -104,7 +104,7 @@ requires:
     redaxo: '^5.14.0'
     packages:
         cronjob: '^2.8.0'
-        yform: '^4.0.0'
+        yform: '>=4.0.0'
 
 installer_ignore:
     - .github

--- a/pages/yform.php
+++ b/pages/yform.php
@@ -76,7 +76,11 @@ if ('' !== $wrapper_class) {
     echo '<div class="',$wrapper_class,'">';
 }
 
-include rex_path::plugin('yform', 'manager', 'pages/data_edit.php');
+if(is_file(rex_path::addon('yform', 'pages/manager.data_edit.php'))) {
+    include rex_path::addon('yform', 'pages/manager.data_edit.php');
+} else {
+    include rex_path::plugin('yform', 'manager', 'pages/data_edit.php');
+}
 
 if ('' !== $wrapper_class) {
     echo '</div>';


### PR DESCRIPTION
 - Implementierung eines Location-Picker zur interaktiven Auswahl einer Position
   - Basis ist ein rex_fragment `PickerWidget`
   - als YForm-Value `rex_yform_value_geolocation_geopicker`
   - als RexForm-Element `PickerElement`
   - als Metafeld `PickerMetafield`
   - in Modulen via `PickerWidget`
   - Erweiterte Dokumentation (insb. "Für Entwickler | PHP: LocationPicker")
- Geocoding mit Nominatim/OSM (via Proxy) im Picker integriert
- Klasse `SqlTools`: 
   - liefert Bausteine für SQL-Abfragen z.B. zur Umkreissuche
   - einfachere Implementierung der Spatial-Funktionen in SQL-Abfragen
- Dino-Logo hinzugefügt: README.MD und BE-Seite. (Dino by @skerbis)
- Vendor-Update für "mjaschen/phpgeo" aus Version 6.0.0
- Kompatibilität zu YForm 5 hergestellt wg. Wegfall der Plugins


closes #173
closes #176
