### PR TITLE
Nach removeTable verbleibende Einträge in rex_yform_fields löschen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 24.08.2025 2.5.2
+
+- Bugfix
+  - **uninstall.php** löscht zusätzlich Einträge in `rex_yform_field`, die durch den regulären Löschvorgang nicht entfernt wurden (#184).
+
 ## 22.08.2025 2.5.1
 
 - Bugfix

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: geolocation
-version: '2.5.1'
+version: '2.5.2'
 license: 'MIT'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/geolocation

--- a/uninstall.php
+++ b/uninstall.php
@@ -10,6 +10,7 @@
  *  Entfernt die Tabellen rex_geolocation_mapset und rex_geolocation_layer.
  *  Löscht die YForm-Tablemanager-Einträge für die Tabellen
  *  Löscht Cronjobs vom Typ Geolocation\Cronjob
+ *  Löscht den Metafeld-Typ
  *
  *  Das Verzeichnis redaxo/data/addons/geolocaton wird nicht gelöscht, da hier Instanz-spezifische
  *  Konfigurationsbestandteile vom Admin update-sicher abgelegt werden können.
@@ -21,27 +22,56 @@ use FriendsOfRedaxo\Geolocation\Picker\PickerMetafield;
 
 try {
     $tables = [
-        rex::getTable('geolocation_layer'),
-        rex::getTable('geolocation_mapset'),
+        'layer' => rex::getTable('geolocation_layer'),
+        'mapset' => rex::getTable('geolocation_mapset'),
     ];
+    $sql = rex_sql::factory();
 
-    // Tabellen löschen
+    /**
+     * Tabellen löschen
+     * 
+     * Aus unbekannten Gründen verbleiben nach dem Löschen der Formulardaten aus rex_yform_field
+     * für die Tabelle rex_geolocation_mapset die Feldeinträge vom Typ geolocation_layerselect
+     * Und nur die; sie werden sogar neu angelegt wenn zuvor das Formulat manuell gelöscht wurde
+     * Wie schräg ist das denn .... Lösung als Workaround: die Felder manuell löschen
+     */
     foreach ($tables as $table) {
         rex_yform_manager_table_api::removeTable($table);
         rex_sql_table::get($table)->drop();
     }
+    $sql->setTable(rex::getTable('yform_field'));
+    $sql->setWhere(
+        'type_name=:type_name AND table_name=:table_name',
+        [
+            'table_name' => $tables['mapset'],
+            'type_name' => 'geolocation_layerselect'
+        ]
+    );
+    $sql->delete();
+    rex_logger::factory()->log('info', 'Geolocation: Tabellen gelöscht; ' . $sql->getRows() . ' Felder aus yform_field entfernt');
 
-    // Cronjobs löschen
-    $sql = rex_sql::factory();
+    /**
+     * Cronjobs löschen
+     */
     $sql->setTable(rex::getTable('cronjob'));
     $sql->setWhere('type=:type', [':type' => 'FriendsOfRedaxo\\Geolocation\\Cronjob']);
     $sql->delete();
 
-    // Meta-Feldtyp löschen
-    // Falls es Metafelder mit diesem Typ gibt .... die hängen dann im luftleeren Raum.
+    /**
+     * Meta-Feldtyp löschen
+     * Falls es Metafelder mit diesem Typ gibt .... die hängen sonst im luftleeren Raum.
+     * Die Metafelder selbst werden nicht gelöscht, da sie ja auch in anderen Addons genutzt werden könnten.
+     *
+     * Falls das Addon bereits dealtiviert ist, kann die Klasse PickerMetafield nicht ausgelesen werden.
+     * Daher wird ggf. die Klasse wieder geladen
+     */
+    if (!class_exists(PickerMetafield::class)) {
+        require_once __DIR__ . '/lib/Picker/PickerMetafield.php';
+    }
     $sql->setTable(rex::getTable('metainfo_type'));
     $sql->setWhere(['label' => PickerMetafield::META_FIELD_TYPE]);
     $sql->delete();
+
 } catch (RuntimeException $e) {
     $this->setProperty('installmsg', $e->getMessage());
 }


### PR DESCRIPTION
Dieser PR ist ein Workaround für die im Issue #182 geschilderten Probleme.

Die Geolocation-Tabellen werden bis Version 2.5.1 via `uninstall.php` so gelöscht:
```php
    foreach ($tables as $table) {
        rex_yform_manager_table_api::removeTable($table);
        rex_sql_table::get($table)->drop();
    }
```

Danach sind immer noch die zwei Felder vom Typ `geolocation_layerselect` vorhanden, die irgendwann zum Crash führen. Das eigentliche Problem ist noch nicht geklärt. Aber per Workaround kann man Geolocation absichern:

Dazu werden per SQL die fraglichen Zeilen direkt aus der Tabelle `rex_yform_field` entfernt.

```php
    $sql->setTable(rex::getTable('yform_field'));
    $sql->setWhere(
        'type_name=:type_name AND table_name=:table_name',
        [
            ':table_name' => $tables['mapset'],
            ':type_name' => 'geolocation_layerselect'
        ]
    );
    $sql->delete();
```

Nebenbei die `uninstall.php` etwas umgestellt und auch das Problem abgesichert, dass beim Uninstall aus einem **deaktivierten** Addon die Klasse `PickerMetafield` nicht verfügbar ist.

closes #182 